### PR TITLE
Update kubeadm scenario

### DIFF
--- a/getting-started-with-kubeadm/step5.md
+++ b/getting-started-with-kubeadm/step5.md
@@ -10,4 +10,4 @@ The status of the Pod creation can be viewed using `kubectl get pods`{{execute H
 
 Once running, you can see the Docker Container running on the node.
 
-`docker ps | head -n2`{{execute HOST2}}
+`docker ps | grep docker-http-server`{{execute HOST2}}


### PR DESCRIPTION
Updated command to check running docker-http-server container in kubernetes worker node.

Original output:
```
root@node:~# docker ps | head -n2
CONTAINER ID        IMAGE
                                               COMMAND                  CREATED             STATUS
            PORTS               NAMES
a2db0f579570        gcr.io/google_containers/k8s-dns-sidecar-amd64@sha256:97074c951046e37d3cbb98b82a
e85ed15704a290cce66a8314e7f846404edde9         "/sidecar --v=2 --log"   3 minutes ago       Up 3 min
utes                            k8s_sidecar_kube-dns-2425271678-0sprq_kube-system_da540f93-a065-11e7
-a971-0242ac110011_0
```

Updated command:
```
root@node:~# docker ps | grep docker-http-server
10cb3a09236c        katacoda/docker-http-server@sha256:76dc8a47fd019f80f2a3163aba789faf55b41b2fb0639
7653610c754cb12d3ee                            "/app"                   7 minutes ago       Up 7 min
utes                            k8s_http_http-366312056-pg42f_default_6d82d78e-a067-11e7-a971-0242ac
110011_0
```
